### PR TITLE
prefill domain and method on home from URL query params

### DIFF
--- a/web/templates/layouts/home.tpl
+++ b/web/templates/layouts/home.tpl
@@ -50,11 +50,11 @@ input, select {
     <p>Enter the domain and validation method you are having trouble issuing a certificate with. <small>(Choose HTTP-01 if unsure)</small>.</p>
     <form action="/" method="POST">
       <div class="fieldset">
-        <input type="text" autofocus tabindex="1" class="domain" name="domain" placeholder="example.org" required>
+        <input type="text" autofocus tabindex="1" class="domain" name="domain" placeholder="example.org" value="{{ .Domain }}" required>
         <select name="method" tabindex="2" class="validation-method">
-          <option value="http-01">HTTP-01</option>
-          <option value="dns-01">DNS-01</option>
-          <option value="tls-alpn-01">TLS-ALPN-01</option>
+          <option value="http-01" {{ if eq "http-01" .Method }} selected {{ end }} >HTTP-01</option>
+          <option value="dns-01" {{ if eq "dns-01" .Method }} selected {{ end }} >DNS-01</option>
+          <option value="tls-alpn-01" {{ if eq "tls-alpn-01" .Method }} selected {{ end }} >TLS-ALPN-01</option>
         </select>
       </div>
       <input class="submit" tabindex="3" type="submit" value="Run Test">

--- a/web/web.go
+++ b/web/web.go
@@ -419,8 +419,13 @@ func (s *server) httpSubmitTest(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) httpHome(w http.ResponseWriter, r *http.Request) {
+	domain := r.URL.Query().Get("domain")
+	method := r.URL.Query().Get("method")
+
 	s.render(w, http.StatusOK, "home.tpl", map[string]interface{}{
 		"WorkerCount": template.HTML(fmt.Sprintf("<!-- Busy Workers: %d -->", atomic.LoadInt32(&s.busyWorkers))),
+		"Domain": domain,
+		"Method": method,
 	})
 }
 


### PR DESCRIPTION
Closes #31 

To make it easy for other websites to integrate with letsdebug, prefill the home page form with values form the URL.

## Testing
Ran `make server-dev`

Checked these URLs:

* http://127.0.0.1:9150 -- Form shows defaults
* http://127.0.0.1:9150/?domain=google.com -- Input shows google.com
* http://127.0.0.1:9150/?method=http-01 -- HTTP-01 selected
* http://127.0.0.1:9150/?method=dns-01 -- DNS-01 selected
* http://127.0.0.1:9150/?method=tls-alpn-01 -- TLS-ALPN-01 selected
* http://127.0.0.1:9150/?domain=google.com&method=dns-01 -- Input shows google.com and DNS-01 selected
* http://127.0.0.1:9150/?method=invalid -- Form shows defaults
* http://127.0.0.1:9150/?domain=&method= -- Form shows defaults